### PR TITLE
Fixed a bug by providing a Type of Pool to Database 'pool' object ins…

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -12,7 +12,7 @@ import { Pool } from "pg";
 // }, 0); // logs correct value
 
 // UPDATES FOR Render.com deployment
-let pool;
+let pool: Pool;
 
 if (process.env.NODE_ENV === "production") {
   // Connection string for deployed environment


### PR DESCRIPTION
Fixed a bug when importing DATABASE object instance (anywhere) FROM database.ts:
(alias) let database: any
import database
Variable 'database' implicitly has type 'any' in some locations where its type cannot be determined

Fixed by giving it a type of Pool provided by pg-library (both the function constructor & type is of same name/imported in a single go).